### PR TITLE
Remove nils and don't delete inside each loop

### DIFF
--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -173,6 +173,7 @@ module SalesforceBulkApi
             if job_status && job_status['state'] && job_status['state'][0] == 'Closed'
               batch_statuses = {}
 
+              # ignore nils for now, since alternative is to pointlessly make API calls that never terminate
               batches_ready = @batch_ids.compact!.all? do |batch_id|
                 batch_state = batch_statuses[batch_id] = self.check_batch_status(batch_id)
                 batch_state && batch_state['state'] && batch_state['state'][0] && !['Queued', 'InProgress'].include?(batch_state['state'][0])

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -181,10 +181,9 @@ module SalesforceBulkApi
               if batches_ready
                 @batch_ids.each do |batch_id|
                   state.insert(0, batch_statuses[batch_id])
-                  @batch_ids.delete(batch_id)
                 end
+                break
               end
-              break if @batch_ids.empty?
             else
               break
             end

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -173,8 +173,10 @@ module SalesforceBulkApi
             if job_status && job_status['state'] && job_status['state'][0] == 'Closed'
               batch_statuses = {}
 
+              @batch_ids.compact!
+
               # ignore nils for now, since alternative is to pointlessly make API calls that never terminate
-              batches_ready = @batch_ids.compact!.all? do |batch_id|
+              batches_ready = @batch_ids.all? do |batch_id|
                 batch_state = batch_statuses[batch_id] = self.check_batch_status(batch_id)
                 batch_state && batch_state['state'] && batch_state['state'][0] && !['Queued', 'InProgress'].include?(batch_state['state'][0])
               end

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -173,9 +173,9 @@ module SalesforceBulkApi
             if job_status && job_status['state'] && job_status['state'][0] == 'Closed'
               batch_statuses = {}
 
+              # ignore nils for now, since alternative is to pointlessly make API calls that never terminate
               @batch_ids.compact!
 
-              # ignore nils for now, since alternative is to pointlessly make API calls that never terminate
               batches_ready = @batch_ids.all? do |batch_id|
                 batch_state = batch_statuses[batch_id] = self.check_batch_status(batch_id)
                 batch_state && batch_state['state'] && batch_state['state'][0] && !['Queued', 'InProgress'].include?(batch_state['state'][0])

--- a/lib/salesforce_bulk_api/job.rb
+++ b/lib/salesforce_bulk_api/job.rb
@@ -173,7 +173,7 @@ module SalesforceBulkApi
             if job_status && job_status['state'] && job_status['state'][0] == 'Closed'
               batch_statuses = {}
 
-              batches_ready = @batch_ids.all? do |batch_id|
+              batches_ready = @batch_ids.compact!.all? do |batch_id|
                 batch_state = batch_statuses[batch_id] = self.check_batch_status(batch_id)
                 batch_state && batch_state['state'] && batch_state['state'][0] && !['Queued', 'InProgress'].include?(batch_state['state'][0])
               end


### PR DESCRIPTION
- remove batch_ids that are nils, otherwise `self.check_batch_status(batch_id)` hits a different endpoint and returns a different shaped response, and never correctly terminates the while loop
- don't delete elements inside an `each` loop, since that messes up the indexing